### PR TITLE
[DI-1277] Serilog to use SQLServer and PostgreSQL

### DIFF
--- a/DataImport.Common/Logging/IngestionLogEnricher.cs
+++ b/DataImport.Common/Logging/IngestionLogEnricher.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using DataImport.Models;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace DataImport.Common.Logging
+{
+    public class IngestionLogEnricher : ILogEventEnricher
+    {
+        private const string TableName = "IngestionLog";
+        private const string LogTypeProperty = "LogType";
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent.Properties.ContainsKey(TableName))
+            {
+                logEvent.AddProperty(LogTypeProperty, TableName);
+                LogEventPropertyValue value;
+                if (logEvent.Properties.TryGetValue(TableName, out value) &&
+                    value is StructureValue sv)
+                {
+                    foreach (var item in sv.Properties)
+                    {
+                        if (item.Value is ScalarValue scalar && scalar.Value != null)
+                        {
+                            if (scalar.Value is IngestionResult rawValue)
+                            {
+                                logEvent.AddProperty(item.Name, (int) rawValue);
+                            }
+                            else if (scalar.Value is string stringValue)
+                            {
+                                logEvent.AddProperty(item.Name, stringValue);
+                            }
+                            else
+                            {
+                                logEvent.AddProperty(item.Name, scalar.Value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DataImport.Common/Logging/LoggerExtensions.cs
+++ b/DataImport.Common/Logging/LoggerExtensions.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace DataImport.Common.Logging
+{
+    public static class LoggerExtensions
+    {
+        private const string LogType = "ApplicationLog";
+        public static void LogToTable(this ILogger logger, string message, object model, string logType = LogType)
+        {
+            Dictionary<string, object> dictionary = new Dictionary<string, object>
+            {
+                { $"@{logType}", model }
+            };
+            using (logger.BeginScope(dictionary))
+            {
+                logger.LogInformation(message);
+            }
+        }
+    }
+
+}

--- a/DataImport.Common/Preprocessors/PowerShellPreprocessorOptionsResolver.cs
+++ b/DataImport.Common/Preprocessors/PowerShellPreprocessorOptionsResolver.cs
@@ -21,7 +21,7 @@ namespace DataImport.Common.Preprocessors
         {
             var powerShellPreprocessorOptions = new PowerShellPreprocessorOptions();
 
-            var psOptions = _dataImportDbContext.Configurations.Select(x => new { x.AvailableCmdlets, ImportPSModules = x.ImportPsModules }).SingleOrDefault();
+            var psOptions = _dataImportDbContext.Configurations.Select(x => new { x.AvailableCmdlets, ImportPSModules = x.ImportPSModules }).SingleOrDefault();
             if (psOptions != null)
             {
                 powerShellPreprocessorOptions.MergeOptions(psOptions.AvailableCmdlets, psOptions.ImportPSModules);

--- a/DataImport.Models/Configuration.cs
+++ b/DataImport.Models/Configuration.cs
@@ -9,6 +9,6 @@ namespace DataImport.Models
     {
         public bool InstanceAllowUserRegistration { get; set; } = true;
         public string AvailableCmdlets { get; set; }
-        public string ImportPsModules { get; set; }
+        public string ImportPSModules { get; set; }
     }
 }

--- a/DataImport.Server.TransformLoad/DataImport.Server.TransformLoad.csproj
+++ b/DataImport.Server.TransformLoad/DataImport.Server.TransformLoad.csproj
@@ -54,7 +54,10 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.6.1" />
     <PackageReference Include="Serilog.Sinks.Postgresql.Alternative" Version="3.4.1" />
     <PackageReference Include="SSH.NET" Version="2020.0.1" />

--- a/DataImport.Server.TransformLoad/MappedResource.cs
+++ b/DataImport.Server.TransformLoad/MappedResource.cs
@@ -10,6 +10,9 @@ namespace DataImport.Server.TransformLoad
     public class MappedResource
     {
         public int? AgentId { get; set; }
+        public string AgentName { get; set; }
+        public string ApiServerName { get; set; }
+        public string ApiVersion { get; set; }
         public string FileName { get; set; }
         public string ResourcePath { get; set; }
         public string Metadata { get; set; }

--- a/DataImport.Server.TransformLoad/Program.cs
+++ b/DataImport.Server.TransformLoad/Program.cs
@@ -111,6 +111,7 @@ namespace DataImport.Server.TransformLoad
                 .Enrich.FromLogContext()
                 .Enrich.With<EmptyRequestInfoEnricher>()
                 .Enrich.With<LevelShortNameEnricher>()
+                .Enrich.With<IngestionLogEnricher>()
                 .Enrich.WithMachineName();
         }
     }

--- a/DataImport.Web.Tests/Features/Configuration/EditConfigurationTests.cs
+++ b/DataImport.Web.Tests/Features/Configuration/EditConfigurationTests.cs
@@ -112,34 +112,34 @@ namespace DataImport.Web.Tests.Features.Configuration
                 var configuration = d.Configurations.Single();
 
                 configuration.AvailableCmdlets = "Some-Cmdlet";
-                configuration.ImportPsModules = "Some-PsModule";
+                configuration.ImportPSModules = "Some-PsModule";
 
                 return configuration;
             });
 
             var config = Query(d => d.Configurations.Single());
             config.AvailableCmdlets.ShouldBe("Some-Cmdlet");
-            config.ImportPsModules.ShouldBe("Some-PsModule");
+            config.ImportPSModules.ShouldBe("Some-PsModule");
 
             var editForm = await Send(new EditConfiguration.Query());
             await Send(ViewModelToCommand(editForm));
 
             config = Query(d => d.Configurations.Single());
             config.AvailableCmdlets.ShouldBe("Some-Cmdlet");
-            config.ImportPsModules.ShouldBe("Some-PsModule");
+            config.ImportPSModules.ShouldBe("Some-PsModule");
 
             Query(d =>
             {
                 var configuration = d.Configurations.Single();
 
                 configuration.AvailableCmdlets = null;
-                configuration.ImportPsModules = null;
+                configuration.ImportPSModules = null;
 
                 return configuration;
             });
             config = Query(d => d.Configurations.Single());
             config.AvailableCmdlets.ShouldBeNull();
-            config.ImportPsModules.ShouldBeNull();
+            config.ImportPSModules.ShouldBeNull();
         }
     }
 }

--- a/logging.json
+++ b/logging.json
@@ -1,21 +1,22 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "WebOptimizer": "Warning"
-      }
-    },
-    "Using":  [ "Serilog.Sinks.Console"],
-    "WriteTo": {
-      "ConsoleSink": {
-        "Name": "Console",
-        "Args": {
-          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss,fff}] [{LevelShortName}] [{SourceContext}] {Message} {Exception} {NewLine}"
+    "Serilog": {
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information",
+                "WebOptimizer": "Warning"
+            }
+        },
+        "Using": [ "Serilog.Sinks.Console" ],
+        "WriteTo": {
+            "ConsoleSink": {
+                "Name": "Console",
+                "Args": {
+                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss,fff}] [{LevelShortName}] [{SourceContext}] {Message} {Exception} {NewLine}"
+                }
+            }
         }
-      }
+        
     }
-  }
 }

--- a/logging_PgSql.json
+++ b/logging_PgSql.json
@@ -1,70 +1,169 @@
 {
-  "Serilog": {  
-    "WriteTo": [
-      {
-        "Name": "PostgreSQL",
-        "Args": {
-          "connectionString": "defaultConnection",
-          "tableName": "ApplicationLogs",
-          "schemaName": "public",
-          "needAutoCreateTable": false,
-          "loggerColumnOptions": {
-            "Id": "IdAutoIncrement",
-            "Logged": "Timestamp",
-            "Properties": "LogEvent",
-            "Message": "RenderedMessage",
-            "Exception": "Exception"
-          },
-          "loggerPropertyColumnOptions": {
-            "MachineName": {
-              "Name": "MachineName",
-              "Format": "{l}",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "Level": {
-              "Name": "LevelShortName",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "UserName": {
-              "Name": "UserName",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "Logger": {
-              "Name": "SourceContext",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "ServerName": {
-              "Name": "ServerName",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "Port": {
-              "Name": "ServerPort",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "Url": {
-              "Name": "Url",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "ServerAddress": {
-              "Name": "LocalAddress",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
-            },
-            "RemoteAddress": {
-              "Name": "RemoteAddress",
-              "WriteMethod": "Raw",
-              "DbType": "Varchar"
+    "Serilog": {
+        "WriteTo:Ingestionlog": {
+            "Name": "Conditional",
+            "Args": {
+                "expression": "LogType = 'IngestionLog'",
+                "configureSink": [
+                    {
+                        "Name": "PostgreSQL",
+                        "Args": {
+                            "connectionString": "defaultConnection",
+                            "tableName": "IngestionLogs",
+                            "schemaName": "public",
+                            "needAutoCreateTable": false,
+                            "loggerColumnOptions": {
+                                "Id": "IdAutoIncrement",
+                                "Date": "Timestamp"
+                            },
+                            "loggerPropertyColumnOptions": {
+                                "EducationOrganizationId": {
+                                    "Name": "EducationOrganizationId",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Uuid"
+                                },
+                                "Level": {
+                                    "Name": "Level",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Operation": {
+                                    "Name": "Operation",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Process": {
+                                    "Name": "Process",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "FileName": {
+                                    "Name": "FileName",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Result": {
+                                    "Name": "Result",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Integer"
+                                },
+                                "RowNumber": {
+                                    "Name": "RowNumber",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "EndPointUrl": {
+                                    "Name": "EndPointUrl",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "HttpStatusCode": {
+                                    "Name": "HttpStatusCode",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Data": {
+                                    "Name": "Data",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "OdsResponse": {
+                                    "Name": "OdsResponse",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "AgentName": {
+                                    "Name": "AgentName",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "ApiServerName": {
+                                    "Name": "ApiServerName",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "ApiVersion": {
+                                    "Name": "ApiVersion",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                }
+                            }
+                        }
+                    }
+                ]
             }
-          }         
+        },
+        "WriteTo:AppLog": {
+            "Name": "Conditional",
+            "Args": {
+                "expression": "LogType is null",
+                "configureSink": [
+                    {
+                        "Name": "PostgreSQL",
+                        "Args": {
+                            "connectionString": "defaultConnection",
+                            "tableName": "ApplicationLogs",
+                            "schemaName": "public",
+                            "needAutoCreateTable": false,
+                            "loggerColumnOptions": {
+                                "Id": "IdAutoIncrement",
+                                "Logged": "Timestamp",
+                                "Properties": "LogEvent",
+                                "Message": "RenderedMessage",
+                                "Exception": "Exception"
+                            },
+                            "loggerPropertyColumnOptions": {
+                                "MachineName": {
+                                    "Name": "MachineName",
+                                    "Format": "{l}",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Level": {
+                                    "Name": "LevelShortName",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "UserName": {
+                                    "Name": "UserName",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Logger": {
+                                    "Name": "SourceContext",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "ServerName": {
+                                    "Name": "ServerName",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Port": {
+                                    "Name": "ServerPort",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "Url": {
+                                    "Name": "Url",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "ServerAddress": {
+                                    "Name": "LocalAddress",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                },
+                                "RemoteAddress": {
+                                    "Name": "RemoteAddress",
+                                    "WriteMethod": "Raw",
+                                    "DbType": "Varchar"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
         }
-      }
-    ]
-  }
+    }
 }

--- a/logging_Sql.json
+++ b/logging_Sql.json
@@ -1,92 +1,229 @@
-{ 
-  "Serilog": {  
-    "WriteTo": [
-      {
-        "Name": "MSSqlServer",
-        "Args": {
-          "connectionString": "defaultConnection",
-          "sinkOptionsSection": {
-            "tableName": "ApplicationLogs",
-            "autoCreateSqlTable": false
-          },
-          "columnOptionsSection": {
-            "disableTriggers": true,
-            "clusteredColumnstoreIndex": false,
-            "primaryKeyColumnName": "Id",
-            "addStandardColumns": [ "Message", "Exception", "LogEvent" ],
-            "removeStandardColumns": [ "MessageTemplate", "Properties", "Level" ],
-            "additionalColumns": [
-              {
-                "ColumnName": "MachineName",
-                "DataType": "nvarchar",
-                "DataLength": 200,
-                "PropertyName": "MachineName"
-              },
-              {
-                "ColumnName": "Level",
-                "DataType": "nvarchar",
-                "DataLength": 5,
-                "PropertyName": "LevelShortName"
-              },
-              {
-                "ColumnName": "UserName",
-                "DataType": "nvarchar",
-                "DataLength": 200,
-                "PropertyName": "UserName"
-              },
-              {
-                "ColumnName": "Logger",
-                "DataType": "nvarchar",
-                "DataLength": 300,
-                "PropertyName": "SourceContext"
-              },
-              {
-                "ColumnName": "ServerName",
-                "DataType": "nvarchar",
-                "DataLength": 200,
-                "PropertyName": "ServerName"
-              },
-              {
-                "ColumnName": "Port",
-                "DataType": "nvarchar",
-                "DataLength": 100,
-                "PropertyName": "ServerPort"
-              },
-              {
-                "ColumnName": "Url",
-                "DataType": "nvarchar",
-                "DataLength": 2000,
-                "PropertyName": "Url"
-              },
-              {
-                "ColumnName": "ServerAddress",
-                "DataType": "nvarchar",
-                "DataLength": 100,
-                "PropertyName": "LocalAddress"
-              },
-              {
-                "ColumnName": "RemoteAddress",
-                "DataType": "nvarchar",
-                "DataLength": -1,
-                "PropertyName": "RemoteAddress"
-              }
-            ],
-            "Id": {
-              "nonClusteredIndex": false,
-              "DataType": "bigint"
-            },
-            "TimeStamp": {
-              "columnName": "Logged",
-              "DataType": "datetimeoffset",
-              "DataLength": 7
-            },
-            "LogEvent": {
-              "columnName": "Properties",
-              "excludeStandardColumns": true
+{
+    "Serilog": {
+        "WriteTo:Ingestionlog": {
+            "Name": "Conditional",
+            "Args": {
+                "expression": "LogType = 'IngestionLog'",
+                "configureSink": [
+                    {
+                        "Name": "MSSqlServer",
+                        "Args": {
+                            "connectionString": "defaultConnection",
+                            "sinkOptionsSection": {
+                                "tableName": "IngestionLogs",
+                                "autoCreateSqlTable": false
+                            },
+                            "columnOptionsSection": {
+                                "disableTriggers": true,
+                                "clusteredColumnstoreIndex": false,
+                                "primaryKeyColumnName": "Id",
+                                "addStandardColumns": [],
+                                "removeStandardColumns": [ "MessageTemplate", "Properties", "Level", "Message", "Exception", "LogEvent" ],
+                                "additionalColumns": [
+                                    {
+                                        "ColumnName": "EducationOrganizationId",
+                                        "DataType": "uniqueidentifier",
+                                        "AllowNull": true,
+                                        "PropertyName": "EducationOrganizationId"
+                                    },
+                                    {
+                                        "ColumnName": "Level",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 255,
+                                        "PropertyName": "Level"
+                                    },
+                                    {
+                                        "ColumnName": "Operation",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 255,
+                                        "AllowNull": true,
+                                        "PropertyName": "Operation"
+                                    },
+                                    {
+                                        "ColumnName": "Process",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "AllowNull": true,
+                                        "PropertyName": "Process"
+                                    },
+                                    {
+                                        "ColumnName": "FileName",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "AllowNull": true,
+                                        "PropertyName": "FileName"
+                                    },
+                                    {
+                                        "ColumnName": "Result",
+                                        "DataType": "int",
+                                        "AllowNull": false,
+                                        "PropertyName": "Result"
+                                    },
+                                    {
+                                        "ColumnName": "RowNumber",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "AllowNull": true,
+                                        "PropertyName": "RowNumber"
+                                    },
+                                    {
+                                        "ColumnName": "EndPointUrl",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "AllowNull": true,
+                                        "PropertyName": "EndPointUrl"
+                                    },
+                                    {
+                                        "ColumnName": "HttpStatusCode",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "AllowNull": true,
+                                        "PropertyName": "HttpStatusCode"
+                                    },
+                                    {
+                                        "ColumnName": "Data",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "PropertyName": "Data"
+                                    },
+                                    {
+                                        "ColumnName": "OdsResponse",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "AllowNull": true,
+                                        "PropertyName": "OdsResponse"
+                                    },
+                                    {
+                                        "ColumnName": "AgentName",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 255,
+                                        "AllowNull": true,
+                                        "PropertyName": "AgentName"
+                                    },
+                                    {
+                                        "ColumnName": "ApiServerName",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 255,
+                                        "AllowNull": true,
+                                        "PropertyName": "ApiServerName"
+                                    },
+                                    {
+                                        "ColumnName": "ApiVersion",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 20,
+                                        "AllowNull": true,
+                                        "PropertyName": "ApiVersion"
+                                    }
+                                ],
+                                "Id": {
+                                    "nonClusteredIndex": false,
+                                    "DataType": "bigint"
+                                },
+                                "TimeStamp": {
+                                    "columnName": "Date",
+                                    "DataType": "datetimeoffset",
+                                    "DataLength": 7
+                                }
+                            }
+                        }
+                    }
+                ]
             }
-          }
+        },
+        "WriteTo:AppLog": {
+            "Name": "Conditional",
+            "Args": {
+                "expression": "LogType is null",
+                "configureSink": [
+                    {
+                        "Name": "MSSqlServer",
+                        "Args": {
+                            "connectionString": "defaultConnection",
+                            "sinkOptionsSection": {
+                                "tableName": "ApplicationLogs",
+                                "autoCreateSqlTable": false
+                            },
+                            "columnOptionsSection": {
+                                "disableTriggers": true,
+                                "clusteredColumnstoreIndex": false,
+                                "primaryKeyColumnName": "Id",
+                                "addStandardColumns": [ "Message", "Exception", "LogEvent" ],
+                                "removeStandardColumns": [ "MessageTemplate", "Properties", "Level" ],
+                                "additionalColumns": [
+                                    {
+                                        "ColumnName": "MachineName",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 200,
+                                        "PropertyName": "MachineName"
+                                    },
+                                    {
+                                        "ColumnName": "Level",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 5,
+                                        "PropertyName": "LevelShortName"
+                                    },
+                                    {
+                                        "ColumnName": "UserName",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 200,
+                                        "PropertyName": "UserName"
+                                    },
+                                    {
+                                        "ColumnName": "Logger",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 300,
+                                        "PropertyName": "SourceContext"
+                                    },
+                                    {
+                                        "ColumnName": "ServerName",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 200,
+                                        "PropertyName": "ServerName"
+                                    },
+                                    {
+                                        "ColumnName": "Port",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 100,
+                                        "PropertyName": "ServerPort"
+                                    },
+                                    {
+                                        "ColumnName": "Url",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 2000,
+                                        "PropertyName": "Url"
+                                    },
+                                    {
+                                        "ColumnName": "ServerAddress",
+                                        "DataType": "nvarchar",
+                                        "DataLength": 100,
+                                        "PropertyName": "LocalAddress"
+                                    },
+                                    {
+                                        "ColumnName": "RemoteAddress",
+                                        "DataType": "nvarchar",
+                                        "DataLength": -1,
+                                        "PropertyName": "RemoteAddress"
+                                    }
+                                ],
+                                "Id": {
+                                    "nonClusteredIndex": false,
+                                    "DataType": "bigint"
+                                },
+                                "TimeStamp": {
+                                    "columnName": "Logged",
+                                    "DataType": "datetimeoffset",
+                                    "DataLength": 7
+                                },
+                                "LogEvent": {
+                                    "columnName": "Properties",
+                                    "excludeStandardColumns": true
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
         }
-      }
-    ]
-  }
+
+    }
 }


### PR DESCRIPTION
@CSR2017 @jasonh-edfi  
This is the Serilog implementation to use the IngestionLog table. The PostgreSQL issue has been fixed by changing the column name in the file DataImport.Models/Configuration.cs

