### PR TITLE
Feature/form options config

### DIFF
--- a/DataImport.Web/Startup.cs
+++ b/DataImport.Web/Startup.cs
@@ -33,7 +33,6 @@ using DataImport.Web.Infrastructure.Security;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using DataImport.Web.Middleware;
-using Microsoft.AspNetCore.Http.Features;
 
 namespace DataImport.Web
 {
@@ -70,7 +69,6 @@ namespace DataImport.Web
             services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));
             services.Configure<IdentitySettings>(Configuration.GetSection("IdentitySettings"));
             services.Configure<ConnectionStrings>(Configuration.GetSection("ConnectionStrings"));
-            services.Configure<FormOptions>(Configuration.GetSection("FormOptions"));
             services.Configure<ExternalPreprocessorOptions>(_configuration.GetSection("ExternalPreprocessors"));
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
             services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(sp => sp.GetService<ILogger<NoLoggingCategoryPlaceHolder>>());

--- a/DataImport.Web/Startup.cs
+++ b/DataImport.Web/Startup.cs
@@ -33,6 +33,7 @@ using DataImport.Web.Infrastructure.Security;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using DataImport.Web.Middleware;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace DataImport.Web
 {
@@ -69,6 +70,7 @@ namespace DataImport.Web
             services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));
             services.Configure<IdentitySettings>(Configuration.GetSection("IdentitySettings"));
             services.Configure<ConnectionStrings>(Configuration.GetSection("ConnectionStrings"));
+            services.Configure<FormOptions>(Configuration.GetSection("FormOptions"));
             services.Configure<ExternalPreprocessorOptions>(_configuration.GetSection("ExternalPreprocessors"));
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
             services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(sp => sp.GetService<ILogger<NoLoggingCategoryPlaceHolder>>());


### PR DESCRIPTION
Add service configuration for FormOptions, this will allow users to have more control over DataImport Web Form configuration and default limit values. 

If the section is present in the config file, values that are present will override default values, if the section is not defined in config, or values that are not set in the configuration section will take default values.

This change will solve an issue where a DataMap reaches the default limit of allowed values (elements in the form say: scores, performance levels, objective assessments, etc) and for this reason will throw an error when trying to save the DataMap. An example of this is the Dibels template (DIBELS_8th_and_Next_Edition_Assessment_-_API_3+_(DataImport_v1.2)), it seems the template was created on an earlier version of DataImport that did not have the web form limit.


example config section in (appsettings.json)
The following configuration section will allow a Form to contain more than the default limit of 1024 values.
{
...
    "FormOptions": {
        "ValueCountLimit": 5000        
    },
...
}


